### PR TITLE
security fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function setBoard(req, res) {
             return;
         }
 
-        if (Number(lm) > Number(status.boards[boardNum].lm)) {
+        if (Number(lm) > Number(status.boards[boardNum].lm) && Number(lm) < new Date().getTime()) {
             status.boards[boardNum].board = newData;
             status.boards[boardNum].name = name;
             status.boards[boardNum].lm = lm;


### PR DESCRIPTION
there was no input validation on the timestamp submitted. usual process:
- server serves up the board with the current time (t=100000)
- player plays game, submits with t=100000
- someone else requests the board 5 minutes later (t=100300)
- that someone else plays, and submits with t=100300 all fine and dandy. both players get to change the server-side state of the board (and if everyone's playing on an unmodded client, but multiple people load the same board, the final person to load it gets to have the final say in its state. that's fine. pretty smart, really)

but! the first player can lie and say they received the board at t=200000, and then the "someone else" fetches at 100300 and their write never gets logged. in theory, someone could write a board with an arbitrarily high timestamp and edit the board data to spell a bad word or something. the fix: reject boards that the player claims to have fetched in the future. you could even reject boards that aren't 2 or more minutes in the past, but I'm not trying to overcomplicate things.