### PR TITLE
sanity check board state

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function setBoard(req, res) {
             }
         }
 
-        if (isNaN(Number(newData))) {
+        if (isNaN(Number(newData)) || !/^(?:[0-7]{10})+$/.test(newData)) {
             return;
         }
 


### PR DESCRIPTION
in today's Javascript Moment, we fix a few bugs
- a null string board state will crash any client that tries to load it (pretty bad!)
- an 8 or 9 will render as ghost versions of the red and orange minos
- a negative sign, decimal point, e, or Infinity will be invisible minos
- a string that isn't a multiple of 10 characters will be quietly truncated from the start when the client loads it (not a bug, but may as well not allow it)

this does not check for 
- full rows (something that legitimate clients can send by placing a block right before their time runs out)
- empty rows below non-empty rows (could, in theory, have happened started from a unique starting state such as the one in board 6)
- a significant difference from the previous board state (could occur with careful timing. e.g. player 1 loads the board on odd minutes and upstacks while player 2 loads the board on even minutes and downstacks)